### PR TITLE
Some more basic optimizations

### DIFF
--- a/src/AweSOM/CompileSOMClassTest.class.st
+++ b/src/AweSOM/CompileSOMClassTest.class.st
@@ -100,10 +100,12 @@ CompileSOMClassTest >> test05UnsharedFieldInMethodSubClass [
 		withArguments: instance.
 	privateInstVarNames := instance class instVarNames select: [ :each | (each beginsWith: 'som') not ].
 	privateInstVarNames do: 
-		[ :each | 
+		[ :each |
+		| instVarVal |
+		instVarVal := instance instVarNamed: each.
 		self 
-			assert: ((universe newNumber: 42) primEqual: (instance instVarNamed: each))
-			equals: (universe globalAt: #false) ]
+			assert: ((instVarVal isKindOf: SOMNumber) and: [instVarVal number = 42])
+			equals: false ]
 ]
 
 { #category : #tests }

--- a/src/AweSOM/SOMBlock.class.st
+++ b/src/AweSOM/SOMBlock.class.st
@@ -51,6 +51,11 @@ SOMBlock >> primrestart [
 ]
 
 { #category : #accessing }
+SOMBlock >> setDefaultClass [
+	"NO-OP, is set explicitly on object creation"
+]
+
+{ #category : #accessing }
 SOMBlock >> somBlockMethod [
 	^ somBlockMethod
 ]

--- a/src/AweSOM/SOMNumber.class.st
+++ b/src/AweSOM/SOMNumber.class.st
@@ -59,6 +59,12 @@ SOMNumber >> primEqual: other [
 ]
 
 { #category : #primitives }
+SOMNumber >> primEqualEqual: otherObject [ 
+
+	^ self universe newBool: number == otherObject number
+]
+
+{ #category : #primitives }
 SOMNumber >> primLowerThan: other [
 	
 	^ universe newBool: self number < other number

--- a/src/AweSOM/SOMNumber.class.st
+++ b/src/AweSOM/SOMNumber.class.st
@@ -53,9 +53,7 @@ SOMNumber >> primAnd: other [
 { #category : #primitives }
 SOMNumber >> primEqual: other [
 
-	^ universe newBool: 
-		((other isKindOf: SOMNumber)
-			and: [self number = other number])
+	^ universe newBool: self number = other number
 ]
 
 { #category : #primitives }

--- a/src/AweSOM/SOMObject.class.st
+++ b/src/AweSOM/SOMObject.class.st
@@ -147,6 +147,12 @@ SOMObject >> isSOMSymbol [
 ]
 
 { #category : #accessing }
+SOMObject >> number [
+	"Needed to allow value equality for SOMNumber objects in SOMNumber>>#primEqualEqual:"
+	^ nil
+]
+
+{ #category : #accessing }
 SOMObject >> numberOfFields [
 	^ fields size
 ]

--- a/src/AweSOM/SOMUniverse.class.st
+++ b/src/AweSOM/SOMUniverse.class.st
@@ -272,9 +272,8 @@ SOMUniverse >> globalBlockClass [
 
 { #category : #'gobal accessing' }
 SOMUniverse >> globalBlockClass: numArgs [
-	| className |
-	className := 'Block', (numArgs + 1) asString.
-	^ self loadSOMClass: className asSymbol
+	^ somBlockClasses at: numArgs + 1
+
 ]
 
 { #category : #'gobal accessing' }
@@ -421,6 +420,9 @@ SOMUniverse >> initializeObjectSystem [
 	
 	"Load the generic block class"
 	somBlockClass := self loadSOMClass: #Block.
+	somBlockClasses at: 1 put: (self loadSOMClass: #Block1).
+	somBlockClasses at: 2 put: (self loadSOMClass: #Block2).
+	somBlockClasses at: 3 put: (self loadSOMClass: #Block3).
 	
 	"Setup the true and false objects"
 	somTrueClass := self loadSOMClass: #True.

--- a/src/AweSOM/SOMUniverse.class.st
+++ b/src/AweSOM/SOMUniverse.class.st
@@ -481,6 +481,10 @@ SOMUniverse >> initializeTestObjectSystem [
 	
 	somBlockClass := self newSystemClass.
 	self initializeSystemClass: somBlockClass superclass: somObjectClass named: #Block.
+	somBlockClasses at: 1 put: somBlockClass.
+	somBlockClasses at: 2 put: somBlockClass.
+	somBlockClasses at: 3 put: somBlockClass.
+
 
 	self initializeGlobalsDict: somNilObject.
 

--- a/src/AweSOM/SOMUniverse.class.st
+++ b/src/AweSOM/SOMUniverse.class.st
@@ -6,7 +6,6 @@ Class {
 		'interpreter',
 		'outStream',
 		'symbolTable',
-		'numberCache',
 		'exitCode',
 		'isInitialized',
 		'somObjectClass',
@@ -28,7 +27,8 @@ Class {
 		'somFalseClass',
 		'somSystemClass',
 		'somNilObject',
-		'somBlockClass'
+		'somBlockClass',
+		'somBlockClasses'
 	],
 	#classVars : [
 		'ClassPaths',
@@ -380,7 +380,7 @@ SOMUniverse >> initialize [
 	self interpreter: (self class defaultInterpreter inUniverse: self).
 	globals := IdentityDictionary new.
 	symbolTable := SOMSymbolTable in: self.
-	numberCache := IdentityDictionary new.
+	somBlockClasses := Array new: 3.
 
 	exitCode := 0.
 	isInitialized := false.
@@ -602,9 +602,7 @@ SOMUniverse >> newMetaclassClass [
 { #category : #'object creation' }
 SOMUniverse >> newNumber: number [
 
-	^ self numberCache
-		at: number
-		ifAbsentPut: [SOMNumber create: number in: self].
+	^ SOMNumber create: number in: self.
 ]
 
 { #category : #'object creation' }
@@ -630,16 +628,6 @@ SOMUniverse >> newSystemClass [
 	systemClass somClass somClass: somMetaclassClass.
 	
 	^ systemClass
-]
-
-{ #category : #accessing }
-SOMUniverse >> numberCache [
-	^ numberCache
-]
-
-{ #category : #accessing }
-SOMUniverse >> numberCache: anObject [
-	numberCache := anObject
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- remove number cache
- use array of block classes instead of string concatenation
- avoid computing name of SOMBlock default class

This gives another good speedup.
The main bottleneck is send performance, which requires a polymorphic inline cache to be fixed, I think. A simple invocable lookup table may also help.